### PR TITLE
feat: added run-name

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,5 +1,6 @@
 ---
 name: Generate Registry
+run-name: Generate Registry (${{inputs.package}})
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: aquaproj/aqua-installer@61e2563dfe7674cbf74fe6ec212e444198a3bb00 # v2.0.2
         with:
-          aqua_version: v1.34.1
+          aqua_version: v1.34.2
         env:
           GITHUB_TOKEN: ${{github.token}}
       - run: aqua gr --deep --out-testdata pkg.yaml "$PKG" | tee registry.yaml


### PR DESCRIPTION
Added `run-name` to make it easier to identify packages in GitHub Actions.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name

before
![image](https://user-images.githubusercontent.com/29038315/222946382-96d38f7e-b8df-4272-90e5-4368b4365f5a.png)

after
![image](https://user-images.githubusercontent.com/29038315/222946395-387b85e0-28c9-4bfa-bfb8-c64b1977c5ce.png)
